### PR TITLE
bug: tag alignment, connection reference

### DIFF
--- a/docs/examples/do_basics/do_basics.yaml
+++ b/docs/examples/do_basics/do_basics.yaml
@@ -1,11 +1,10 @@
 - name: DO
   hosts: bigip
-  connection: local
+  connection: httpapi
   gather_facts: false
 
-  tasks:   
-
+  tasks:
     - name: Deploy DO Declaration
       f5networks.f5_bigip.bigip_do_deploy:
         content: "{{ lookup('file', 'declarations/do.json') }}"
-        tags: [ deploy ]
+      tags: [deploy]


### PR DESCRIPTION
Compared to AS3 Example, the connection for DO should be 'httpapi'.  Additionally, when attempting to run a simple playbook, I was getting an error indicated below which was caused by 'tags:' not being properly aligned.

TASK [Deploy DO Declaration] **********************************************************************************************************fatal: [crf5poc01]: FAILED! => changed=false 
  msg: 'Unsupported parameters for (f5networks.f5_bigip.bigip_do_deploy) module: tags. Supported parameters include: timeout, task_id, 
content.'